### PR TITLE
Restart supervisor when a process exits with a fatal state, e.g. too many start retries too quickly

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,8 +35,10 @@ COPY user-settings_template.yml /app/rocketpool/user-settings_template.yml
 COPY rocketpool-start.sh /usr/local/bin/rocketpool-start.sh
 COPY restart-vc.sh /usr/local/bin/restart-vc.sh
 COPY stop-validator.sh /usr/local/bin/stop-validator.sh
+COPY stop-supervisor.sh /usr/local/bin/stop-supervisor.sh
 RUN chmod +x /usr/local/bin/rocketpool-start.sh
 RUN chmod +x /usr/local/bin/restart-vc.sh
 RUN chmod +x /usr/local/bin/stop-validator.sh
+RUN chmod +x /usr/local/bin/stop-supervisor.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/stop-supervisor.sh
+++ b/build/stop-supervisor.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+printf "INIT stop-supervisor.sh\n";
+
+while read line; do
+  echo "Processing Event: $line" >&2;
+  kill -3 $(cat "/var/run/supervisord.pid")
+done < /dev/stdin

--- a/build/supervisord.conf
+++ b/build/supervisord.conf
@@ -1,5 +1,9 @@
 [supervisord]
 nodaemon=true
+loglevel=info
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+childlogdir=/var/log/supervisor
 
 [program:rocketpool]
 command=/bin/sh -c "/usr/local/bin/rocketpool-start.sh"
@@ -31,3 +35,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[eventlistener:processes]
+command=/usr/local/bin/stop-supervisor.sh
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_FATAL


### PR DESCRIPTION
Fixed https://github.com/dappnode/DAppNodePackage-rocketpool/issues/7